### PR TITLE
Simplify API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val nameVal = "zeppelin-jar-loader"
 name := nameVal
 
-val versionVal = "v0.1.0"
+val versionVal = "v0.2.0"
 version := versionVal
 
 val scalaVersionVal = "2.11.12"


### PR DESCRIPTION
- Since it is very common to have multiple assets, force asset name to be specified. This is a major version change.
- Allow directory path for output, since it is very common for user to use back the asset name as the output file name anyway.