### PR TITLE
Build for both Scala versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # `zeppelin-jar-loader`
 
-[![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/datagovsg%2Fzeppelin-jar-loader%2Fzeppelin-jar-loader?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/zeppelin-jar-loader/builds?repoOwner=datagovsg&repoName=zeppelin-jar-loader&serviceName=datagovsg%2Fzeppelin-jar-loader&filter=trigger:build~Build;branch:master;pipeline:5cf7855468eff96e20da05a6~zeppelin-jar-loader)
+| Scala 2.11 | Scala 2.12 |
+|:-:|:-:|
+| [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/dsaidgovsg%2Fzeppelin-jar-loader%2Fscala-2.11?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/scala-2.11/builds?repoOwner=dsaidgovsg&repoName=zeppelin-jar-loader&serviceName=dsaidgovsg%2Fzeppelin-jar-loader&filter=trigger:build~Build;branch:master;pipeline:5d53c5c7fc481525f307e681~scala-2.11)| [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/dsaid/dsaidgovsg%2Fzeppelin-jar-loader%2Fscala-2.12?key=eyJhbGciOiJIUzI1NiJ9.NWNhNDBjNDA1MTMxODZjZjdhMTUyYjQx.uEnKk6__Qzfhrurzdo57Oly3AhBgrjFWZZrovG-m-8E&type=cf-1)]( https://g.codefresh.io/pipelines/scala-2.12/builds?filter=trigger:build~Build;pipeline:5d7730333794ab50ffcbd169~scala-2.12) |
 
 Provides a simple JAR loader for dynamic loading of JAR files at the start for
 Zeppelin.

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,12 @@
 val nameVal = "zeppelin-jar-loader"
 name := nameVal
 
-val versionVal = "v0.2.0"
+val versionVal = "v0.2.1"
 version := versionVal
 
-val scalaVersionVal = "2.11.12"
+val scalaVersionVal = sys.env.get("SCALA_VERSION").getOrElse("2.11.12")
+
+unmanagedBase := baseDirectory.value / "libs"
 
 lazy val testScalafmt = taskKey[Unit]("testScalafmt")
 
@@ -14,7 +16,7 @@ lazy val commonSettings = Seq(
   resolvers += DefaultMavenRepository,
   libraryDependencies ++= Seq(
     // Common test dependencies
-    "org.apache.zeppelin" %% "zeppelin-spark" % "0.7.3",
+    "org.apache.zeppelin" % "spark-interpreter" % "0.8.1",
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   ),
   // Disable parallel test execution to avoid SparkSession conflicts
@@ -29,7 +31,7 @@ def assemblySettings = Seq(
       MergeStrategy.discard
     case x => MergeStrategy.first
   },
-  assemblyJarName in assembly := f"${nameVal}-${versionVal}.jar",
+  assemblyJarName in assembly := f"${nameVal}_${scalaVersionVal}-${versionVal}.jar",
 )
 
 lazy val root = (project in file(".")).settings(

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val versionVal = "v0.2.1"
 version := versionVal
 
 val scalaVersionVal = sys.env.get("SCALA_VERSION").getOrElse("2.11.12")
+val scalaXYVersionVal = scalaVersionVal.split(raw"\.").take(2).mkString(".")
 
 unmanagedBase := baseDirectory.value / "libs"
 
@@ -31,7 +32,7 @@ def assemblySettings = Seq(
       MergeStrategy.discard
     case x => MergeStrategy.first
   },
-  assemblyJarName in assembly := f"${nameVal}_${scalaVersionVal}-${versionVal}.jar",
+  assemblyJarName in assembly := f"${nameVal}_${scalaXYVersionVal}-${versionVal}.jar",
 )
 
 lazy val root = (project in file(".")).settings(

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -5,6 +5,7 @@ stages:
 - build
 - release
 
+# Requires SCALA_VERSION (x.y.z) to be specified
 steps:
   get_github_token:
     title: Get default GitHub token
@@ -21,10 +22,16 @@ steps:
     repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
     revision: ${{CF_REVISION}}
 
+  extract_xy_scala_version:
+    title: Extract Scala x.y version
+    image: alpine:3.10
+    commands:
+    - cf_export SCALA_XY_VERSION="$(echo ${SCALA_VERSION} | cut -d '.' -f1,2)"
+
   test:
     title: Run unit tests
     stage: test
-    image: hseeberger/scala-sbt:8u181_2.12.8_1.2.8
+    image: hseeberger/scala-sbt:8u212_1.2.8_2.12.9
     working_directory: ${{main_clone}}
     commands:
     - sbt -ivy /codefresh/volume/.ivy2 test
@@ -32,10 +39,10 @@ steps:
   build_jar:
     title: Build 
     stage: build
-    image: hseeberger/scala-sbt:8u181_2.12.8_1.2.8
+    image: hseeberger/scala-sbt:8u212_1.2.8_2.12.9
     working_directory: ${{main_clone}}
     commands:
-    - rm -f target/scala-2.11/*.jar
+    - rm -f target/scala-${SCALA_XY_VERSION}/*.jar
     - sbt -ivy /codefresh/volume/.ivy2 assembly
 
   upload_jar:
@@ -52,4 +59,4 @@ steps:
       fi
     - |-
       ghr -t ${{GITHUB_TOKEN}} -u ${{CF_REPO_OWNER}} -r ${{CF_REPO_NAME}} \
-          -c ${{CF_REVISION}} -replace ${TAG_NAME} target/scala-2.11/zeppelin-jar-loader-*.jar
+          -c ${{CF_REVISION}} -replace ${TAG_NAME} target/scala-${SCALA_XY_VERSION}/zeppelin-jar-loader-*.jar

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -61,4 +61,4 @@ steps:
       fi
     - |-
       ghr -t ${{GITHUB_TOKEN}} -u ${{CF_REPO_OWNER}} -r ${{CF_REPO_NAME}} \
-          -c ${{CF_REVISION}} -replace ${TAG_NAME} target/scala-${SCALA_XY_VERSION}/zeppelin-jar-loader-*.jar
+          -c ${{CF_REVISION}} -replace ${TAG_NAME} target/scala-${SCALA_XY_VERSION}/zeppelin-jar-loader_*.jar

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,6 +1,7 @@
 version: '1.0'
 stages:
 - clone
+- misc
 - test
 - build
 - release
@@ -24,6 +25,7 @@ steps:
 
   extract_xy_scala_version:
     title: Extract Scala x.y version
+    stage: misc
     image: alpine:3.10
     commands:
     - cf_export SCALA_XY_VERSION="$(echo ${SCALA_VERSION} | cut -d '.' -f1,2)"


### PR DESCRIPTION
Both JARs are tagged with the Scala version `x.y`.

Also updated the deprecated dep:
`"org.apache.zeppelin" %% "zeppelin-spark" % "0.7.3",`
to
`"org.apache.zeppelin" % "spark-interpreter" % "0.8.1",`.

The code implementation remains the same.