### PR TITLE
Allow spark-interpreter jar to be provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val nameVal = "zeppelin-jar-loader"
 name := nameVal
 
-val versionVal = "v0.2.1"
+val versionVal = "v0.2.2"
 version := versionVal
 
 val scalaVersionVal = sys.env.get("SCALA_VERSION").getOrElse("2.11.12")
@@ -19,7 +19,7 @@ lazy val commonSettings = Seq(
   resolvers += DefaultMavenRepository,
   libraryDependencies ++= Seq(
     // Common test dependencies
-    "org.apache.zeppelin" % "spark-interpreter" % zeppelinVersionVal,
+    "org.apache.zeppelin" % "spark-interpreter" % zeppelinVersionVal % "provided",
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   ),
   // Disable parallel test execution to avoid SparkSession conflicts
@@ -34,7 +34,7 @@ def assemblySettings = Seq(
       MergeStrategy.discard
     case x => MergeStrategy.first
   },
-  assemblyJarName in assembly := f"${nameVal}_${versionVal}_${scalaXYVersionVal}_zeppelin-${zeppelinVersionVal}.jar",
+  assemblyJarName in assembly := f"${nameVal}_${scalaXYVersionVal}_${versionVal}_zeppelin-${zeppelinVersionVal}.jar",
 )
 
 lazy val root = (project in file(".")).settings(


### PR DESCRIPTION
Also switch back the ordering so that the version values are easier to read.